### PR TITLE
#154 Pipeline not failing when small number of tests fail [BUG]

### DIFF
--- a/.github/workflows/pull_request_pipeline.yml
+++ b/.github/workflows/pull_request_pipeline.yml
@@ -127,8 +127,8 @@ jobs:
         working-directory: ./frontend
         run: |
             mkdir -p reports
-            flutter test --machine | dart run junitreport:tojunit > reports/test_report.xml || echo "Tests failed, continuing..."
-            flutter test --coverage || echo "Coverage failed, continuing..."
+            flutter test --machine | dart run junitreport:tojunit > reports/test_report.xml
+            flutter test --coverage
 
             if [ -f coverage/lcov.info ]; then
               # Convert relative paths to absolute paths


### PR DESCRIPTION
## Issue: #154 - Pipeline not failing when small number of tests fail [BUG]

### Description  
The CI/CD pipeline was incorrectly passing even when some tests failed, allowing faulty code to be merged into the main branch. This issue compromised the stability of the project.  

**Fix:**  
- Removed the lines that allowed the pipeline to continue running even after test failures.  
- Ensured that test failures will now stop the pipeline immediately.  

### Main Files Affected  
- `.github/workflows/pull_request_pipeline.yml`  

### Completion Criteria  
- [x] Pipeline fails when any test fails.  
- [x] Developers are alerted to test failures before merging.  
- [x] No faulty code can be merged into the main branch.  

### Type of Change  
- [ ] New feature  
- [x] Bug fix  
- [ ] Refactoring  
- [ ] Added tests to existing code  
- [ ] Documentation update required  

### How Has This Been Tested?  
- Ran the modified pipeline on a test branch with both passing and failing tests.  
- Verified that the pipeline correctly fails when tests fail.  

### Tests Added  
- No new tests added, but the change ensures existing tests function correctly.  
