### PR TITLE
[PATCH] New Loyola maps

### DIFF
--- a/frontend/lib/screens/indoor/mappedin_map_screen.dart
+++ b/frontend/lib/screens/indoor/mappedin_map_screen.dart
@@ -36,6 +36,7 @@ class _MappedinMapScreenState extends State<MappedinMapScreen> {
     "Library Building": "67ba2570a39568000bc4b334",
     "Vanier Extension": "67f1f4f13060f8000b74964b",
     "Vanier Library": "67f2ebec0b03ee000b42fd40",
+    "Central Building": "67f2f0370b03ee000b42fd41"
   };
 
   @override


### PR DESCRIPTION
This pull request includes a small change to the `frontend/lib/screens/indoor/mappedin_map_screen.dart` file. The change adds three new building identifiers to the `_MappedinMapScreenState` class. 

Adds Loyola maps to the codebase

* Added identifiers for "Vanier Extension", "Vanier Library", and "Central Building".